### PR TITLE
Initial support of pipeline build for Windows

### DIFF
--- a/azure-pipelines-official-windows.yml
+++ b/azure-pipelines-official-windows.yml
@@ -16,7 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+schedules:
+- cron: "0 0 * * *"
+  displayName: Windows.GitBash.Official
+  branches:
+    include:
+    - master
+  always: true
 jobs:
 - job: Test
   pool:

--- a/azure-pipelines-official-windows.yml
+++ b/azure-pipelines-official-windows.yml
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 schedules:
-- cron: "0 0 * * *"
+- cron: "0 */6 * * *"
   displayName: Windows.GitBash.Official
   branches:
     include:

--- a/azure-pipelines-official-windows.yml
+++ b/azure-pipelines-official-windows.yml
@@ -1,0 +1,107 @@
+#
+# Copyright 2013-2019 the original author or authors from the JHipster project.
+#
+# This file is part of the JHipster project, see https://www.jhipster.tech/
+# for more information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+jobs:
+- job: Test
+  pool:
+    vmImage: 'windows-2019'
+  variables:
+    JHI_PROFILE: dev
+    JHI_RUN_APP: 1
+    JHI_PROTRACTOR: 0
+    JHI_ENTITY: sql
+    # if JHI_LIB_BRANCH value is release, use the release from Maven
+    JHI_LIB_REPO: https://github.com/jhipster/jhipster.git
+    JHI_LIB_BRANCH: master
+    # if JHI_GEN_BRANCH value is release, use the release from NPM
+    JHI_GEN_REPO: https://github.com/jhipster/generator-jhipster.git
+    JHI_GEN_BRANCH: master
+    # specific config
+    SPRING_OUTPUT_ANSI_ENABLED: NEVER
+    SPRING_JPA_SHOW_SQL: false
+    JHI_DISABLE_WEBPACK_LOGS: true
+    JHI_E2E_HEADLESS: true
+    JHI_SCRIPTS: $HOME/generator-jhipster/test-integration/scripts
+
+  strategy:
+    matrix:
+      ngx-default:
+        JHI_APP: ngx-default
+        JHI_PROFILE: prod
+        JHI_PROTRACTOR: 1
+        JHI_ENTITY: sql
+      ngx-psql-es-noi18n-mapsid:
+        JHI_APP: ngx-psql-es-noi18n-mapsid
+        JHI_PROFILE: prod
+        JHI_PROTRACTOR  : 1
+        JHI_ENTITY: sql
+      ngx-gradle-fr:
+        JHI_APP: ngx-gradle-fr
+        JHI_PROFILE: prod
+        JHI_PROTRACTOR: 1
+        JHI_ENTITY: sql
+      ngx-mariadb-oauth2-sass-infinispan:
+        JHI_APP: ngx-mariadb-oauth2-sass-infinispan
+        JHI_PROTRACTOR: 1
+        JHI_ENTITY: sql
+      ms-ngx-gateway-eureka:
+        JHI_APP: ms-ngx-gateway-eureka
+        JHI_ENTITY: sql
+      ms-micro-eureka:
+        JHI_APP: ms-micro-eureka
+        JHI_ENTITY: micro
+      ngx-mongodb-kafka-cucumber:
+        JHI_APP: ngx-mongodb-kafka-cucumber
+        JHI_ENTITY: mongodb
+      react-default:
+        JHI_APP: react-default
+        JHI_PROFILE: prod
+        JHI_PROTRACTOR: 1
+        JHI_ENTITY: sql
+      react-noi18n-es-ws-gradle-session:
+        JHI_APP: react-noi18n-es-ws-gradle-session
+        JHI_PROFILE: prod
+        JHI_PROTRACTOR: 1
+        JHI_ENTITY: sql
+      ms-ngx-gateway-eureka-oauth2:
+        JHI_APP: ms-ngx-gateway-eureka-oauth2
+        JHI_PROTRACTOR: 1
+        JHI_ENTITY: sql
+      ms-ngx-gateway-consul:
+        JHI_APP: ms-ngx-gateway-consul
+        JHI_ENTITY: sql
+      ms-ngx-gateway-uaa:
+        JHI_APP: ms-ngx-gateway-uaa
+        JHI_ENTITY: uaa
+      ms-micro-consul:
+        JHI_APP: ms-micro-consul
+        JHI_ENTITY: micro
+      ngx-session-cassandra-fr:
+        JHI_APP: ngx-session-cassandra-fr
+        JHI_ENTITY: cassandra
+      ngx-couchbase:
+        JHI_APP: ngx-couchbase
+        JHI_PROFILE: prod
+        JHI_ENTITY: couchbase
+      webflux-mongodb:
+        JHI_APP: webflux-mongodb
+        JHI_ENTITY: mongodb
+
+  steps:
+  - template: azure-template-windows.yml

--- a/azure-pipelines-official-windows.yml
+++ b/azure-pipelines-official-windows.yml
@@ -92,9 +92,6 @@ jobs:
       ms-micro-consul:
         JHI_APP: ms-micro-consul
         JHI_ENTITY: micro
-      ngx-session-cassandra-fr:
-        JHI_APP: ngx-session-cassandra-fr
-        JHI_ENTITY: cassandra
       ngx-couchbase:
         JHI_APP: ngx-couchbase
         JHI_PROFILE: prod

--- a/azure-pipelines-official-windows.yml
+++ b/azure-pipelines-official-windows.yml
@@ -92,10 +92,6 @@ jobs:
       ms-micro-consul:
         JHI_APP: ms-micro-consul
         JHI_ENTITY: micro
-      ngx-couchbase:
-        JHI_APP: ngx-couchbase
-        JHI_PROFILE: prod
-        JHI_ENTITY: couchbase
       webflux-mongodb:
         JHI_APP: webflux-mongodb
         JHI_ENTITY: mongodb

--- a/azure-template-windows.yml
+++ b/azure-template-windows.yml
@@ -42,8 +42,6 @@ steps:
   displayName: 'TOOLS: install Yarn'
 - bash: test-integration/scripts/01-display-configuration.sh
   displayName: 'TOOLS: display configuration'
-- bash: test-integration/scripts/03-system.sh
-  displayName: 'TOOLS: configure tools installed by the system'
 - bash: test-integration/scripts/04-git-config.sh
   displayName: 'TOOLS: configure git'
 

--- a/azure-template-windows.yml
+++ b/azure-template-windows.yml
@@ -1,0 +1,78 @@
+#
+# Copyright 2013-2019 the original author or authors from the JHipster project.
+#
+# This file is part of the JHipster project, see https://www.jhipster.tech/
+# for more information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+steps:
+#----------------------------------------------------------------------
+# Install all tools and check configuration
+#----------------------------------------------------------------------
+- task: NodeTool@0
+  inputs:
+    versionSpec: '10.15.3'
+  displayName: 'TOOLS: install Node.js'
+- pwsh: Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jdk_x64_windows_hotspot_11.0.4_11.zip" -OutFile AdoptOpenJDK.zip
+  displayName: 'TOOLS: Download AdoptOpenJDK'
+- task: JavaToolInstaller@0
+  inputs:
+    versionSpec: "11"
+    jdkArchitectureOption: x64
+    jdkSourceOption: LocalDirectory
+    jdkFile: "AdoptOpenJDK.zip"
+    jdkDestinationDirectory: "/Java"
+    cleanDestinationDirectory: true
+  displayName: 'TOOLS: Configure AdoptOpenJDK'
+- script: npm install -g npm
+  displayName: 'TOOLS: update NPM'
+- script: npm install -g yarn
+  displayName: 'TOOLS: install Yarn'
+- bash: test-integration/scripts/01-display-configuration.sh
+  displayName: 'TOOLS: display configuration'
+- bash: test-integration/scripts/03-system.sh
+  displayName: 'TOOLS: configure tools installed by the system'
+- bash: test-integration/scripts/04-git-config.sh
+  displayName: 'TOOLS: configure git'
+
+#----------------------------------------------------------------------
+# Install JHipster and generate project+entities
+#----------------------------------------------------------------------
+- bash: test-integration/scripts/10-install-jhipster-daily-builds.sh
+  displayName: 'GENERATION: install JHipster'
+- bash: $(JHI_SCRIPTS)/11-generate-entities.sh
+  displayName: 'GENERATION: entities'
+- bash: $(JHI_SCRIPTS)/12-generate-project.sh
+  displayName: 'GENERATION: project'
+- bash: $(JHI_SCRIPTS)/13-replace-version-generated-project.sh
+  displayName: 'GENERATION: replace version in generated project'
+- bash: $(JHI_SCRIPTS)/14-jhipster-info.sh
+  displayName: 'GENERATION: jhipster info'
+
+#----------------------------------------------------------------------
+# Bugs fix
+#----------------------------------------------------------------------
+- bash: $(JHI_SCRIPTS)/20-no-memory-limit-elasticsearch.sh
+  displayName: 'BUGS-FIX: no memory limit for Elasticsearch'
+
+#----------------------------------------------------------------------
+# Launch tests
+#----------------------------------------------------------------------
+- bash: $(JHI_SCRIPTS)/21-tests-backend.sh
+  displayName: 'TESTS: backend'
+- bash: $(JHI_SCRIPTS)/22-tests-frontend.sh
+  displayName: 'TESTS: frontend'
+- bash: $(JHI_SCRIPTS)/23-package.sh
+  displayName: 'TESTS: packaging'

--- a/test-integration/jdl-scripts/10-install-jhipster-daily-builds.sh
+++ b/test-integration/jdl-scripts/10-install-jhipster-daily-builds.sh
@@ -13,7 +13,7 @@ if [[ "$JHI_REPO" == *"/jhipster" ]]; then
     cd "$JHI_HOME"
     git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
 
-    ./mvnw clean install -Dgpg.skip=true
+    ./mvnw -ntp clean install -Dgpg.skip=true
 
 elif [[ "$JHI_LIB_BRANCH" == "release" ]]; then
     echo "*** jhipster: use release version"
@@ -32,7 +32,7 @@ else
 
     test-integration/scripts/10-replace-version-jhipster.sh
 
-    ./mvnw clean install -Dgpg.skip=true
+    ./mvnw -ntp clean install -Dgpg.skip=true
     ls -al ~/.m2/repository/io/github/jhipster/jhipster-framework/
     ls -al ~/.m2/repository/io/github/jhipster/jhipster-dependencies/
     ls -al ~/.m2/repository/io/github/jhipster/jhipster-parent/

--- a/test-integration/jdl-scripts/23-package.sh
+++ b/test-integration/jdl-scripts/23-package.sh
@@ -8,7 +8,7 @@ source $(dirname $0)/00-init-env.sh
 #-------------------------------------------------------------------------------
 if [[ "$JHI_APP" == *"uaa"* ]]; then
     cd "$JHI_FOLDER_UAA"
-    ./mvnw verify -DskipTests -Pdev
+    ./mvnw -ntp verify -DskipTests -Pdev
     mv target/*.jar app.jar
 fi
 
@@ -33,7 +33,7 @@ for local_folder in $(ls "$JHI_FOLDER_APP"); do
         # Package the application
         #-------------------------------------------------------------------------------
         if [ -f "mvnw" ]; then
-            ./mvnw verify -DskipTests -P"$JHI_PROFILE"
+            ./mvnw -ntp verify -DskipTests -P"$JHI_PROFILE"
             mv target/*.jar app.jar
         elif [ -f "gradlew" ]; then
             ./gradlew bootJar -P"$JHI_PROFILE" -x test
@@ -53,7 +53,7 @@ for local_folder in $(ls "$JHI_FOLDER_APP"); do
         #-------------------------------------------------------------------------------
         if [ "$JHI_WAR" == 1 ]; then
             if [ -f "mvnw" ]; then
-                ./mvnw verify -DskipTests -P"$JHI_PROFILE",war
+                ./mvnw -ntp verify -DskipTests -P"$JHI_PROFILE",war
                 mv target/*.war app.war
             elif [ -f "gradlew" ]; then
                 ./gradlew bootWar -P"$JHI_PROFILE" -Pwar -x test
@@ -74,7 +74,7 @@ for local_folder in $(ls "$JHI_FOLDER_APP"); do
         #-------------------------------------------------------------------------------
         # if [ "$JHI_PKG_DOCKER" == 1 ]; then
             if [ -f "mvnw" ]; then
-                ./mvnw -Pprod verify jib:dockerBuild
+                ./mvnw -ntp -Pprod verify jib:dockerBuild
             elif [ -f "gradlew" ]; then
                 ./gradlew bootJar -Pprod jibDockerBuild
             else

--- a/test-integration/jdl-scripts/26-tests-docker.sh
+++ b/test-integration/jdl-scripts/26-tests-docker.sh
@@ -17,13 +17,13 @@ docker container exec -i jhipster jhipster info --no-insight
 
 # install JHipster dependencies
 docker container exec -i jhipster git clone https://github.com/jhipster/jhipster /home/jhipster/jhipster
-docker container exec -w /home/jhipster/jhipster -e JAVA_HOME=/home/jhipster/.sdkman/candidates/java/current -i jhipster ./mvnw clean install -Dgpg.skip=true
+docker container exec -w /home/jhipster/jhipster -e JAVA_HOME=/home/jhipster/.sdkman/candidates/java/current -i jhipster ./mvnw -ntp clean install -Dgpg.skip=true
 
 # generate sample
 docker container exec -i jhipster curl https://raw.githubusercontent.com/jhipster/generator-jhipster/master/test-integration/samples/ngx-default/.yo-rc.json -o .yo-rc.json
 docker container exec -i jhipster ls -al
 docker container exec -i jhipster jhipster --force --no-insight --skip-checks --with-entities
 docker container exec -i jhipster ls -al /home/jhipster/app/
-docker container exec -e JAVA_HOME=/home/jhipster/.sdkman/candidates/java/current -i jhipster ./mvnw test
+docker container exec -e JAVA_HOME=/home/jhipster/.sdkman/candidates/java/current -i jhipster ./mvnw -ntp test
 docker container exec -i jhipster npm test
-docker container exec -e JAVA_HOME=/home/jhipster/.sdkman/candidates/java/current -i jhipster ./mvnw package -Pprod
+docker container exec -e JAVA_HOME=/home/jhipster/.sdkman/candidates/java/current -i jhipster ./mvnw -ntp package -Pprod

--- a/test-integration/scripts/10-install-jhipster-daily-builds.sh
+++ b/test-integration/scripts/10-install-jhipster-daily-builds.sh
@@ -13,7 +13,7 @@ if [[ "$JHI_REPO" == *"/jhipster" ]]; then
     cd "$JHI_HOME"
     git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
 
-    ./mvnw clean install -Dgpg.skip=true
+    ./mvnw -ntp clean install -Dgpg.skip=true
 
 elif [[ "$JHI_LIB_BRANCH" == "release" ]]; then
     echo "*** jhipster: use release version"
@@ -32,7 +32,7 @@ else
 
     test-integration/scripts/10-replace-version-jhipster.sh
 
-    ./mvnw clean install -Dgpg.skip=true
+    ./mvnw -ntp clean install -Dgpg.skip=true
     ls -al ~/.m2/repository/io/github/jhipster/jhipster-framework/
     ls -al ~/.m2/repository/io/github/jhipster/jhipster-dependencies/
     ls -al ~/.m2/repository/io/github/jhipster/jhipster-parent/

--- a/test-integration/scripts/26-tests-docker.sh
+++ b/test-integration/scripts/26-tests-docker.sh
@@ -17,13 +17,13 @@ docker container exec -i jhipster jhipster info --no-insight
 
 # install JHipster dependencies
 docker container exec -i jhipster git clone https://github.com/jhipster/jhipster /home/jhipster/jhipster
-docker container exec -w /home/jhipster/jhipster -i jhipster ./mvnw clean install -Dgpg.skip=true
+docker container exec -w /home/jhipster/jhipster -i jhipster ./mvnw -ntp clean install -Dgpg.skip=true
 
 # generate sample
 docker container exec -i jhipster curl https://raw.githubusercontent.com/jhipster/generator-jhipster/master/test-integration/samples/ngx-default/.yo-rc.json -o .yo-rc.json
 docker container exec -i jhipster ls -al
 docker container exec -i jhipster jhipster --force --no-insight --skip-checks --with-entities
 docker container exec -i jhipster ls -al /home/jhipster/app/
-docker container exec -i jhipster ./mvnw verify
+docker container exec -i jhipster ./mvnw -ntp verify
 docker container exec -i jhipster npm test
-docker container exec -i jhipster ./mvnw verify -Pprod -DskipTests
+docker container exec -i jhipster ./mvnw -ntp verify -Pprod -DskipTests


### PR DESCRIPTION
This PR is meant initial support and will run the daily builds on windows environment.

- The built-in git bash will be used almost everywhere.
- AdoptOpenJDK 11 is currently used.
- Couchbase and Cassandra tests are removed because of docker problem.
- No docker-compose will be run because of docker problem.
- End-To-End testing is not included this time

@pascalgrimaud I have tested this pipeline. The builds are not much stable, sometimes getting the following kind of error.
After re-running again, the builds are passed.

```
The entity EntityWithServiceImplPaginationAndDTO is being updated.

WARNING! This entity has the DTO option, and it has a relationship with entity "operation" that doesn't have the DTO option. This will result in an error.
WARNING! jpaMetamodelFiltering is missing in .jhipster/Label.json, using 'no' as fallback
WARNING! jpaMetamodelFiltering is missing in .jhipster/FieldTestMapstructEntity.json, using 'no' as fallback
WARNING! jpaMetamodelFiltering is missing in .jhipster/FieldTestServiceImplEntity.json, using 'no' as fallback
WARNING! jpaMetamodelFiltering is missing in .jhipster/EntityWithServiceClass.json, using 'no' as fallback
WARNING! jpaMetamodelFiltering is missing in .jhipster/EntityWithServiceImpl.json, using 'no' as fallback
WARNING! jpaMetamodelFiltering is missing in .jhipster/EntityWithServiceClassAndPagination.json, using 'no' as fallback
WARNING! jpaMetamodelFiltering is missing in .jhipster/EntityWithServiceImplAndPagination.json, using 'no' as fallback
WARNING! jpaMetamodelFiltering is missing in .jhipster/EntityWithServiceClassAndDTO.json, using 'no' as fallback
WARNING! jpaMetamodelFiltering is missing in .jhipster/EntityWithServiceImplAndDTO.json, using 'no' as fallback
WARNING! jpaMetamodelFiltering is missing in .jhipster/EntityWithServiceClassPaginationAndDTO.json, using 'no' as fallback
WARNING! jpaMetamodelFiltering is missing in .jhipster/EntityWithServiceImplPaginationAndDTO.json, using 'no' as fallback
events.js:174
      throw er; // Unhandled 'error' event
      ^

ShellJSInternalError: EEXIST: file already exists, mkdir 'C:\Users\VssAdministrator\app\src\main\resources'
    at Object.mkdirSync (fs.js:752:3)
    at mkdirSyncRecursive (C:\Users\VssAdministrator\generator-jhipster\node_modules\shelljs\src\mkdir.js:32:6)
    at mkdirSyncRecursive (C:\Users\VssAdministrator\generator-jhipster\node_modules\shelljs\src\mkdir.js:29:3)
    at mkdirSyncRecursive (C:\Users\VssAdministrator\generator-jhipster\node_modules\shelljs\src\mkdir.js:29:3)
    at C:\Users\VssAdministrator\generator-jhipster\node_modules\shelljs\src\mkdir.js:81:9
    at Array.forEach (<anonymous>)
    at Object._mkdir (C:\Users\VssAdministrator\generator-jhipster\node_modules\shelljs\src\mkdir.js:59:8)
    at Object.mkdir (C:\Users\VssAdministrator\generator-jhipster\node_modules\shelljs\src\common.js:384:25)
    at module.exports.generateKeyStore (C:\Users\VssAdministrator\generator-jhipster\generators\generator-base.js:1488:21)
    at module.exports.setUp (C:\Users\VssAdministrator\generator-jhipster\generators\server\files.js:1750:18)
Emitted 'error' event at:
    at Immediate.setImmediate (C:\Users\VssAdministrator\generator-jhipster\node_modules\yeoman-generator\lib\index.js:433:22)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
```
