### PR TITLE
Use OpenJDK 8 instead of Zulu

### DIFF
--- a/azure-template.yml
+++ b/azure-template.yml
@@ -34,11 +34,16 @@ steps:
       sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
       java -version
     else
-      echo '*** Using OpenJDK 8 by default'
+      echo '*** Using OpenJDK 8'
+      sudo add-apt-repository ppa:openjdk-r/ppa
+      sudo apt-get update
+      sudo apt-get install -y openjdk-8-jdk
+      sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+      java -version
     fi
   displayName: 'TOOLS: configuring OpenJDK'
 - script: |
-    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - 
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
     sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
     sudo apt update
     sudo apt install google-chrome-stable


### PR DESCRIPTION
Replacing Zulu (Default JDK of Azure) with OpenJDK 8 to get rid of the Test-containers problem. This seems to work in my Azure Builds. 

https://dev.azure.com/sudharakap/sudharakap/_build/results?buildId=239&view=logs&j=14ecf143-eece-5d03-88de-b4dd986b4ce4

Related to: https://github.com/jhipster/generator-jhipster/issues/10594

@pascalgrimaud : Can we try this out? :smile: 