### PR TITLE
Run OpenJDK 8 Everywhere Instead of Azul

### DIFF
--- a/azure-pipelines-jdl-ms-keycloak.yml
+++ b/azure-pipelines-jdl-ms-keycloak.yml
@@ -95,7 +95,12 @@ jobs:
         sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
         java -version
       else
-        echo '*** Using OpenJDK 8 by default'
+        echo '*** Using OpenJDK 8'
+        sudo add-apt-repository ppa:openjdk-r/ppa
+        sudo apt-get update
+        sudo apt-get install -y openjdk-8-jdk
+        sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+        java -version
       fi
     displayName: 'TOOLS: configuring OpenJDK'
   - script: |
@@ -103,7 +108,7 @@ jobs:
       sudo echo "127.0.0.1	keycloak" >> /etc/hosts
     displayName: 'TOOLS: configuring /etc/hosts for keycloak usage'
   - script: |
-      wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - 
+      wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
       sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
       sudo apt update
       sudo apt install google-chrome-stable

--- a/azure-template-plus.yml
+++ b/azure-template-plus.yml
@@ -39,11 +39,16 @@ steps:
       sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
       java -version
     else
-      echo '*** Using OpenJDK 8 by default'
+      echo '*** Using OpenJDK 8'
+      sudo add-apt-repository ppa:openjdk-r/ppa
+      sudo apt-get update
+      sudo apt-get install -y openjdk-8-jdk
+      sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+      java -version
     fi
   displayName: 'TOOLS: configuring OpenJDK'
 - script: |
-    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - 
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
     sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
     sudo apt update
     sudo apt install google-chrome-stable


### PR DESCRIPTION
This is related to https://github.com/jhipster/generator-jhipster/issues/10594

I think we should run OpenJDK 8 to be consistent everywhere. The default Azul OpenJDK  provided by Azure cannot be trusted I think given that we saw some inconsistencies in the above issue with Couchbase. :smile: 