### PR TITLE
Upgrade Ubuntu to Latest for Couchbase

### DIFF
--- a/azure-pipelines-official-openjdk8.yml
+++ b/azure-pipelines-official-openjdk8.yml
@@ -27,7 +27,7 @@ schedules:
 jobs:
 - job: Test
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'ubuntu-latest'
   variables:
     JHI_PROFILE: dev
     JHI_RUN_APP: 1


### PR DESCRIPTION
On Github CI we use `ubuntu-latest` and therefore I want to try out making this consistent with Github CI. 

Related to: https://github.com/jhipster/generator-jhipster/issues/10594