### PR TITLE
Change displayName of Keycloak Schedule

### DIFF
--- a/azure-pipelines-jdl-ms-keycloak.yml
+++ b/azure-pipelines-jdl-ms-keycloak.yml
@@ -18,7 +18,7 @@
 
 schedules:
 - cron: "0 14 * * *"
-  displayName: JDLMs.no.MySQL
+  displayName: JDLMs.Keycloak
   branches:
     include:
     - master


### PR DESCRIPTION
I believe this `displayName` should be changed to reflect the actual name that is being displayed on the Azure builds UI (since we seem to follow this convention for the other builds). Correct me if I am wrong. :smile:  