### PR TITLE
Upgrades to Latest Version of ChromeDriver

### DIFF
--- a/azure-pipelines-jdl-ms-keycloak.yml
+++ b/azure-pipelines-jdl-ms-keycloak.yml
@@ -113,12 +113,11 @@ jobs:
       sudo apt update
       sudo apt install google-chrome-stable
       CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`
-      wget -N http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip -P ~/
-      unzip ~/chromedriver_linux64.zip -d ~/
-      rm ~/chromedriver_linux64.zip
-      sudo mv -f ~/chromedriver /usr/local/bin/chromedriver
-      sudo chown root:root /usr/local/bin/chromedriver
-      sudo chmod 0755 /usr/local/bin/chromedriver
+      wget -q http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip
+      unzip chromedriver_linux64.zip
+      sudo mv chromedriver /usr/bin/chromedriver
+      sudo chown root:root /usr/bin/chromedriver
+      sudo chmod +x /usr/bin/chromedriver
     displayName: 'TOOLS: install google-chrome-stable'
   - script: npm install -g npm
     displayName: 'TOOLS: update NPM'

--- a/azure-pipelines-jdl-ms-keycloak.yml
+++ b/azure-pipelines-jdl-ms-keycloak.yml
@@ -112,6 +112,13 @@ jobs:
       sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
       sudo apt update
       sudo apt install google-chrome-stable
+      CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`
+      wget -N http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip -P ~/
+      unzip ~/chromedriver_linux64.zip -d ~/
+      rm ~/chromedriver_linux64.zip
+      sudo mv -f ~/chromedriver /usr/local/bin/chromedriver
+      sudo chown root:root /usr/local/bin/chromedriver
+      sudo chmod 0755 /usr/local/bin/chromedriver
     displayName: 'TOOLS: install google-chrome-stable'
   - script: npm install -g npm
     displayName: 'TOOLS: update NPM'

--- a/azure-template-plus.yml
+++ b/azure-template-plus.yml
@@ -52,6 +52,13 @@ steps:
     sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
     sudo apt update
     sudo apt install google-chrome-stable
+    CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`
+    wget -N http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip -P ~/
+    unzip ~/chromedriver_linux64.zip -d ~/
+    rm ~/chromedriver_linux64.zip
+    sudo mv -f ~/chromedriver /usr/local/bin/chromedriver
+    sudo chown root:root /usr/local/bin/chromedriver
+    sudo chmod 0755 /usr/local/bin/chromedriver
   displayName: 'TOOLS: install google-chrome-stable'
 - script: npm install -g npm
   displayName: 'TOOLS: update NPM'

--- a/azure-template-plus.yml
+++ b/azure-template-plus.yml
@@ -53,12 +53,11 @@ steps:
     sudo apt update
     sudo apt install google-chrome-stable
     CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`
-    wget -N http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip -P ~/
-    unzip ~/chromedriver_linux64.zip -d ~/
-    rm ~/chromedriver_linux64.zip
-    sudo mv -f ~/chromedriver /usr/local/bin/chromedriver
-    sudo chown root:root /usr/local/bin/chromedriver
-    sudo chmod 0755 /usr/local/bin/chromedriver
+    wget -q http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip
+    unzip chromedriver_linux64.zip
+    sudo mv chromedriver /usr/bin/chromedriver
+    sudo chown root:root /usr/bin/chromedriver
+    sudo chmod +x /usr/bin/chromedriver
   displayName: 'TOOLS: install google-chrome-stable'
 - script: npm install -g npm
   displayName: 'TOOLS: update NPM'

--- a/azure-template.yml
+++ b/azure-template.yml
@@ -48,12 +48,11 @@ steps:
     sudo apt update
     sudo apt install google-chrome-stable
     CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`
-    wget -N http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip -P ~/
-    unzip ~/chromedriver_linux64.zip -d ~/
-    rm ~/chromedriver_linux64.zip
-    sudo mv -f ~/chromedriver /usr/local/bin/chromedriver
-    sudo chown root:root /usr/local/bin/chromedriver
-    sudo chmod 0755 /usr/local/bin/chromedriver
+    wget -q http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip
+    unzip chromedriver_linux64.zip
+    sudo mv chromedriver /usr/bin/chromedriver
+    sudo chown root:root /usr/bin/chromedriver
+    sudo chmod +x /usr/bin/chromedriver
   displayName: 'TOOLS: install google-chrome-stable'
 - script: npm install -g npm
   displayName: 'TOOLS: update NPM'

--- a/azure-template.yml
+++ b/azure-template.yml
@@ -47,6 +47,13 @@ steps:
     sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
     sudo apt update
     sudo apt install google-chrome-stable
+    CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`
+    wget -N http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip -P ~/
+    unzip ~/chromedriver_linux64.zip -d ~/
+    rm ~/chromedriver_linux64.zip
+    sudo mv -f ~/chromedriver /usr/local/bin/chromedriver
+    sudo chown root:root /usr/local/bin/chromedriver
+    sudo chmod 0755 /usr/local/bin/chromedriver
   displayName: 'TOOLS: install google-chrome-stable'
 - script: npm install -g npm
   displayName: 'TOOLS: update NPM'


### PR DESCRIPTION
This is related to https://github.com/jhipster/generator-jhipster/issues/10662. We need to upgrade ChromeDriver since the default ChromeDriver installation seems to be only compatible with Chrome 76.