### PR TITLE
Revert "Upgrades to Latest Version of ChromeDriver"

### DIFF
--- a/azure-pipelines-jdl-ms-keycloak.yml
+++ b/azure-pipelines-jdl-ms-keycloak.yml
@@ -112,12 +112,6 @@ jobs:
       sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
       sudo apt update
       sudo apt install google-chrome-stable
-      CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`
-      wget -q http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip
-      unzip chromedriver_linux64.zip
-      sudo mv chromedriver /usr/bin/chromedriver
-      sudo chown root:root /usr/bin/chromedriver
-      sudo chmod +x /usr/bin/chromedriver
     displayName: 'TOOLS: install google-chrome-stable'
   - script: npm install -g npm
     displayName: 'TOOLS: update NPM'

--- a/azure-template-plus.yml
+++ b/azure-template-plus.yml
@@ -52,12 +52,6 @@ steps:
     sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
     sudo apt update
     sudo apt install google-chrome-stable
-    CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`
-    wget -q http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip
-    unzip chromedriver_linux64.zip
-    sudo mv chromedriver /usr/bin/chromedriver
-    sudo chown root:root /usr/bin/chromedriver
-    sudo chmod +x /usr/bin/chromedriver
   displayName: 'TOOLS: install google-chrome-stable'
 - script: npm install -g npm
   displayName: 'TOOLS: update NPM'

--- a/azure-template.yml
+++ b/azure-template.yml
@@ -47,12 +47,6 @@ steps:
     sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
     sudo apt update
     sudo apt install google-chrome-stable
-    CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`
-    wget -q http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip
-    unzip chromedriver_linux64.zip
-    sudo mv chromedriver /usr/bin/chromedriver
-    sudo chown root:root /usr/bin/chromedriver
-    sudo chmod +x /usr/bin/chromedriver
   displayName: 'TOOLS: install google-chrome-stable'
 - script: npm install -g npm
   displayName: 'TOOLS: update NPM'


### PR DESCRIPTION
Reverts hipster-labs/jhipster-daily-builds#29

I believe we shouldn't be needing this as per https://github.com/jhipster/generator-jhipster/pull/10676. I've noticed that[ webdriver-manager 12.1.7 handles Chrome upgrade automatically](https://github.com/angular/webdriver-manager/blob/legacy/CHANGELOG.md).