### PR TITLE
Add Better Regex Pattern for Emails

### DIFF
--- a/test-integration/jdl-samples/templates/microservice-demo.jdl.ejs
+++ b/test-integration/jdl-samples/templates/microservice-demo.jdl.ejs
@@ -67,7 +67,7 @@ entity Customer {
    firstName String required
    lastName String required
    gender Gender required
-   email String required pattern(/^[^@\s]+@[^@\s]+\.[^@\s]+$/)
+   email String required pattern(/[a-z0-9._+-]{1,20}@[a-z0-9]{3,15}\.[a-z]{2,4}/)
    phone String required
    addressLine1 String required
    addressLine2 String


### PR DESCRIPTION
This replaces our email regex patter with a better one. The previous one generated very long string patterns which does closely represent email addresses; I believe this one generates patterns which more closely resembles an actual email. 

For example with the previous pattern: `tefsdlfsjfsklfjskljfjklsst@te*&&**&&&&&&%^%^%...st.comsdklfjlsdkfjskldfjsldkfj` is a valid email. 

Related to https://github.com/jhipster/generator-jhipster/issues/10704
