### PR TITLE
Adjust Windows Pipeline for Correct JAVA_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ All builds: https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build
 | JDLMs.Redis.MySQL        | [![Build Status][img-jdlms-redis-mysql]][azure-url]        | 15:00 (UTC) |
 | JDLMs.Caffeine.MariaDB   | [![Build Status][img-jdlms-caffeine-mariadb]][azure-url]   | 15:30 (UTC) |
 | JDLMs.Caffeine.MySQL     | [![Build Status][img-jdlms-caffeine-mysql]][azure-url]     | 16:00 (UTC) |
-
+| Windows.GitBash.Official | [![Build Status][img-windows]][azure-url]                  | 16:30 (UTC) |
 
 [azure-url]: https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build
 [img-official]: https://dev.azure.com/hipster-labs/jhipster-daily-builds/_apis/build/status/Official
@@ -75,3 +75,4 @@ All builds: https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build
 [img-jdlms-caffeine-mariadb]: https://dev.azure.com/hipster-labs/jhipster-daily-builds/_apis/build/status/JDLMs.Caffeine.MariaDB
 [img-jdlms-caffeine-mysql]: https://dev.azure.com/hipster-labs/jhipster-daily-builds/_apis/build/status/JDLMs.Caffeine.MySQL
 [img-jdlms-keycloak]: https://dev.azure.com/hipster-labs/jhipster-daily-builds/_apis/build/status/JDLMs.Keycloak
+[img-windows]: https://dev.azure.com/hipster-labs/jhipster-daily-builds/_apis/build/status/Windows.GitBash.Official

--- a/azure-pipelines-official-windows.yml
+++ b/azure-pipelines-official-windows.yml
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 schedules:
-- cron: "0 */6 * * *"
+- cron: "30 16 * * *"
   displayName: Windows.GitBash.Official
   branches:
     include:
@@ -32,6 +32,7 @@ jobs:
     JHI_RUN_APP: 1
     JHI_PROTRACTOR: 0
     JHI_ENTITY: sql
+    JHI_WINDOWS: true
     # if JHI_LIB_BRANCH value is release, use the release from Maven
     JHI_LIB_REPO: https://github.com/jhipster/jhipster.git
     JHI_LIB_BRANCH: master
@@ -100,7 +101,7 @@ jobs:
         JHI_ENTITY: micro
       webflux-mongodb:
         JHI_APP: webflux-mongodb
-        JHI_ENTITY: mongodb
+        JHI_ENTITY: none
 
   steps:
   - template: azure-template-windows.yml

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -110,6 +110,5 @@ jobs:
       webflux-mongodb:
         JHI_APP: webflux-mongodb
         JHI_ENTITY: none
-
   steps:
   - template: azure-template.yml

--- a/test-integration/scripts/00-init-env.sh
+++ b/test-integration/scripts/00-init-env.sh
@@ -35,4 +35,6 @@ JHI_FOLDER_APP="$HOME"/app
 JHI_FOLDER_UAA="$HOME"/uaa
 
 # set correct OpenJDK version
-JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
+if [[ -z "$JHI_WINDOWS" ]]; then
+    JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
+fi


### PR DESCRIPTION
Fixes hipster-labs/jhipster-daily-builds#28

This adds support for the Windows Build in our Daily Builds. The JAVA_HOME needs to be removed as it's specific to Linux environments. 