### PR TITLE
Enable Couchbase builds on Daily Builds

### DIFF
--- a/.github/workflows/couchbase.yaml
+++ b/.github/workflows/couchbase.yaml
@@ -18,14 +18,10 @@
 #
 
 name: Couchbase
-on:
-  push:
-    branches-ignore:
-      - '**'
 # on: [push, pull_request]
-# on:
-#     schedule:
-#         - cron: '0 4 * * *'
+on:
+   schedule:
+       - cron: '0 4 * * *'
 env:
     JHI_RUN_APP: 1
     JHI_JDK: 11


### PR DESCRIPTION
This re-enables Couchbase since we have upgraded testcontainers to 1.14.0 and hopefully this solves Couchbase issues.

Related to https://github.com/hipster-labs/jhipster-daily-builds/issues/46