### PR TITLE
Migrate protractor to generic e2e variable

### DIFF
--- a/.github/workflows/elasticsearch.yaml
+++ b/.github/workflows/elasticsearch.yaml
@@ -55,18 +55,18 @@ jobs:
                       entity: sqllight
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ngx-psql-es-noi18n
                       entity: sqllight
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-caffeine-mariadb.yaml
+++ b/.github/workflows/jdl-ms-caffeine-mariadb.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mariadb-caffeine
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mariadb-caffeine
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mariadb-caffeine
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-caffeine-mysql.yaml
+++ b/.github/workflows/jdl-ms-caffeine-mysql.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mysql-caffeine
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mysql-caffeine
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mysql-caffeine
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-ehcache-mariadb.yaml
+++ b/.github/workflows/jdl-ms-ehcache-mariadb.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mariadb-ehcache
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mariadb-ehcache
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mariadb-ehcache
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-ehcache-mysql.yaml
+++ b/.github/workflows/jdl-ms-ehcache-mysql.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mysql-ehcache
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mysql-ehcache
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mysql-ehcache
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-hazelcast-mariadb.yaml
+++ b/.github/workflows/jdl-ms-hazelcast-mariadb.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mariadb-hazelcast
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mariadb-hazelcast
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mariadb-hazelcast
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-hazelcast-mysql.yaml
+++ b/.github/workflows/jdl-ms-hazelcast-mysql.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mysql-hazelcast
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mysql-hazelcast
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mysql-hazelcast
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-infinispan-mariadb.yaml
+++ b/.github/workflows/jdl-ms-infinispan-mariadb.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mariadb-infinispan
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mariadb-infinispan
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mariadb-infinispan
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-infinispan-mysql.yaml
+++ b/.github/workflows/jdl-ms-infinispan-mysql.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mysql-infinispan
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mysql-infinispan
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mysql-infinispan
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-memcached-mariadb.yaml
+++ b/.github/workflows/jdl-ms-memcached-mariadb.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mariadb-memcached
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mariadb-memcached
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mariadb-memcached
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-memcached-mysql.yaml
+++ b/.github/workflows/jdl-ms-memcached-mysql.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mysql-memcached
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mysql-memcached
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mysql-memcached
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-no-mariadb.yaml
+++ b/.github/workflows/jdl-ms-no-mariadb.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mariadb-no
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mariadb-no
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mariadb-no
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-no-mysql.yaml
+++ b/.github/workflows/jdl-ms-no-mysql.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mysql-no
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mysql-no
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mysql-no
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-redis-mariadb.yaml
+++ b/.github/workflows/jdl-ms-redis-mariadb.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mariadb-redis
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mariadb-redis
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mariadb-redis
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/jdl-ms-redis-mysql.yaml
+++ b/.github/workflows/jdl-ms-redis-mysql.yaml
@@ -57,28 +57,28 @@ jobs:
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: eureka-oauth2-mysql-redis
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-jwt-mysql-redis
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
                   - app-type: consul-oauth2-mysql-redis
                     entity: jdl
                     profile: prod
                     war: 0
-                    protractor: 1
+                    e2e: 1
         env:
           JHI_ENTITY: ${{ matrix.entity }}
           JHI_APP: ${{ matrix.app-type }}
           JHI_PROFILE: ${{ matrix.profile }}
           JHI_WAR: ${{ matrix.war }}
-          JHI_PROTRACTOR: ${{ matrix.protractor }}
+          JHI_E2E: ${{ matrix.e2e }}
         steps:
           #----------------------------------------------------------------------
           # Install all tools and check configuration

--- a/.github/workflows/monolith-oauth2.yaml
+++ b/.github/workflows/monolith-oauth2.yaml
@@ -57,28 +57,28 @@ jobs:
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: react-oauth2
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ngx-oauth2
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-react-oauth2
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/ms-jwt.yaml
+++ b/.github/workflows/ms-jwt.yaml
@@ -61,48 +61,48 @@ jobs:
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ms-micro-eureka
                       entity: micro
                       profile: prod
                       war: 0
-                      protractor: 0
+                      e2e: 0
                     - app-type: ms-ngx-gateway-consul
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ms-micro-consul
                       entity: micro
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ms-ngx-gateway-eureka
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ms-micro-eureka
                       entity: micro
                       profile: prod
                       war: 0
-                      protractor: 0
+                      e2e: 0
                     - app-type: gradle-ms-ngx-gateway-consul
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ms-micro-consul
                       entity: micro
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/ms-oauth2.yaml
+++ b/.github/workflows/ms-oauth2.yaml
@@ -61,56 +61,56 @@ jobs:
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                       run-app: 1
                     - app-type: ms-micro-eureka-oauth2
                       entity: micro
                       profile: prod
                       war: 0
-                      protractor: 0
+                      e2e: 0
                       run-app: 0
                     - app-type: ms-ngx-gateway-consul-oauth2
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                       run-app: 1
                     - app-type: ms-micro-consul-oauth2
                       entity: micro
                       profile: prod
                       war: 0
-                      protractor: 0
+                      e2e: 0
                       run-app: 0
                     - app-type: gradle-ms-ngx-gateway-eureka-oauth2
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                       run-app: 1
                     - app-type: gradle-ms-micro-eureka-oauth2
                       entity: micro
                       profile: prod
                       war: 0
-                      protractor: 0
+                      e2e: 0
                       run-app: 0
                     - app-type: gradle-ms-ngx-gateway-consul-oauth2
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                       run-app: 1
                     - app-type: gradle-ms-micro-consul-oauth2
                       entity: micro
                       profile: prod
                       war: 0
-                      protractor: 0
+                      e2e: 0
                       run-app: 0
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
             JHI_RUN_APP: ${{ matrix.run-app }}
         steps:
             #----------------------------------------------------------------------

--- a/.github/workflows/ms-uaa.yaml
+++ b/.github/workflows/ms-uaa.yaml
@@ -61,48 +61,48 @@ jobs:
                       entity: uaa
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ms-micro-eureka-uaa
                       entity: micro
                       profile: prod
                       war: 0
-                      protractor: 0
+                      e2e: 0
                     # - app-type: ms-ngx-gateway-consul-uaa
                     #   entity: uaa
                     #   profile: prod
                     #   war: 0
-                    #   protractor: 1
+                    #   e2e: 1
                     # - app-type: ms-micro-consul-uaa
                     #   entity: micro
                     #   profile: prod
                     #   war: 0
-                    #   protractor: 1
+                    #   e2e: 1
                     - app-type: gradle-ms-ngx-gateway-eureka-uaa
                       entity: uaa
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ms-micro-eureka-uaa
                       entity: micro
                       profile: prod
                       war: 0
-                      protractor: 0
+                      e2e: 0
                     # - app-type: gradle-ms-ngx-gateway-consul-uaa
                     #   entity: uaa
                     #   profile: prod
                     #   war: 0
-                    #   protractor: 1
+                    #   e2e: 1
                     # - app-type: gradle-ms-micro-consul-uaa
                     #   entity: micro
                     #   profile: prod
                     #   war: 0
-                    #   protractor: 1
+                    #   e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/ngx-gradle-nosql.yaml
+++ b/.github/workflows/ngx-gradle-nosql.yaml
@@ -57,28 +57,28 @@ jobs:
                       entity: mongodb
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ngx-cassandra
                       entity: cassandra
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ngx-couchbase
                       entity: couchbase
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ngx-neo4j
                       entity: neo4j
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/ngx-gradle.yaml
+++ b/.github/workflows/ngx-gradle.yaml
@@ -60,43 +60,43 @@ jobs:
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ngx-sass-noi18n
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ngx-websocket
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ngx-hazelcast-cucumber
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ngx-mariadb-kafka-nol2
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ngx-session
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-ngx-infinispan
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/ngx-maven-nosql.yaml
+++ b/.github/workflows/ngx-maven-nosql.yaml
@@ -57,28 +57,28 @@ jobs:
                       entity: mongodb
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ngx-cassandra
                       entity: cassandra
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ngx-couchbase
                       entity: couchbase
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ngx-neo4j
                       entity: neo4j
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/ngx-maven.yaml
+++ b/.github/workflows/ngx-maven.yaml
@@ -60,43 +60,43 @@ jobs:
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ngx-sass-noi18n
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ngx-websocket
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ngx-hazelcast-cucumber
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ngx-mariadb-kafka-nol2
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ngx-session
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ngx-infinispan
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/no-database.yaml
+++ b/.github/workflows/no-database.yaml
@@ -59,38 +59,38 @@ jobs:
                       entity: none
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ngx-nodatabase-oauth2
                       entity: none
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: ngx-nodatabase-session
                       entity: none
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: react-nodatabase-jwt-gradle
                       entity: none
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: react-nodatabase-oauth2-gradle
                       entity: none
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: react-nodatabase-session-gradle
                       entity: none
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/react-gradle-nosql.yaml
+++ b/.github/workflows/react-gradle-nosql.yaml
@@ -57,28 +57,28 @@ jobs:
                       entity: mongodb
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-react-cassandra
                       entity: cassandra
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     # - app-type: gradle-react-couchbase
                     #   entity: couchbase
                     #   profile: prod
                     #   war: 0
-                    #   protractor: 1
+                    #   e2e: 1
                     # - app-type: gradle-react-neo4j
                     #   entity: neo4j
                     #   profile: prod
                     #   war: 0
-                    #   protractor: 1
+                    #   e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/react-gradle.yaml
+++ b/.github/workflows/react-gradle.yaml
@@ -60,43 +60,43 @@ jobs:
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-react-sass-noi18n
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-react-websocket
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-react-hazelcast-cucumber
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-react-mariadb-kafka-nol2
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-react-session
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: gradle-react-infinispan
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/react-maven-nosql.yaml
+++ b/.github/workflows/react-maven-nosql.yaml
@@ -57,28 +57,28 @@ jobs:
                       entity: mongodb
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: react-cassandra
                       entity: cassandra
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     # - app-type: react-couchbase
                     #   entity: couchbase
                     #   profile: prod
                     #   war: 0
-                    #   protractor: 1
+                    #   e2e: 1
                     # - app-type: react-neo4j
                     #   entity: neo4j
                     #   profile: prod
                     #   war: 0
-                    #   protractor: 1
+                    #   e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/react-maven.yaml
+++ b/.github/workflows/react-maven.yaml
@@ -60,43 +60,43 @@ jobs:
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: react-sass-noi18n
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: react-websocket
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: react-hazelcast-cucumber
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: react-mariadb-kafka
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: react-session
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: react-infinispan
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/vue-gradle-nosql.yaml
+++ b/.github/workflows/vue-gradle-nosql.yaml
@@ -57,28 +57,28 @@ jobs:
                       entity: mongodb
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-gradle-cassandra
                       entity: cassandra
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-gradle-couchbase
                       entity: couchbase
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-gradle-neo4j
                       entity: neo4j
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/vue-gradle.yaml
+++ b/.github/workflows/vue-gradle.yaml
@@ -62,53 +62,53 @@ jobs:
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-gradle-mysql
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-gradle-noi18n
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-gradle-fulli18n-fr
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-gradle-oauth2
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-gradle-session
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-gradle-es
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-gradle-websocket
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-gradle-theme
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/vue-maven-nosql.yaml
+++ b/.github/workflows/vue-maven-nosql.yaml
@@ -57,28 +57,28 @@ jobs:
                       entity: mongodb
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-maven-cassandra
                       entity: cassandra
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-maven-couchbase
                       entity: couchbase
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-maven-neo4j
                       entity: neo4j
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/vue-maven.yaml
+++ b/.github/workflows/vue-maven.yaml
@@ -62,53 +62,53 @@ jobs:
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-maven-mysql
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-maven-noi18n
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-maven-fulli18n-fr
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-maven-oauth2
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-maven-session
                       entity: sqlfull
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-maven-es
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-maven-websocket
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                     - app-type: vue-maven-theme
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -24,7 +24,7 @@ on:
         - cron: '30 8 * * *'
 env:
     JHI_RUN_APP: 1
-    JHI_PROTRACTOR: 0
+    JHI_E2E: 0
     JHI_ENTITY: sql
     JHI_WINDOWS: true
     # if JHI_LIB_BRANCH value is release, use the release from Maven
@@ -62,19 +62,19 @@ jobs:
                 include:
                     - app-type: ngx-default
                       profile: prod
-                      protractor: 1
+                      e2e: 1
                       entity: sql
                     - app-type: ngx-psql-es-noi18n-mapsid
                       profile: prod
-                      protractor: 1
+                      e2e: 1
                       entity: sql
                     - app-type: ngx-gradle-fr
                       profile: prod
-                      protractor: 1
+                      e2e: 1
                       entity: sql
                     - app-type: ngx-mariadb-oauth2-sass-infinispan
                       profile: prod
-                      protractor: 1
+                      e2e: 1
                       entity: sql
                     - app-type: ms-ngx-gateway-eureka
                       profile: prod
@@ -89,7 +89,7 @@ jobs:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.profile }}
-            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_E2E: ${{ matrix.e2e }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration


### PR DESCRIPTION
With the adding of Cypress, (https://github.com/jhipster/generator-jhipster/pull/12307) JHipster CI/CD script have been using "e2e" variable name instead of "protractor".