### PR TITLE
use jhipster bom repo

### DIFF
--- a/.github/workflows/neo4j.yaml
+++ b/.github/workflows/neo4j.yaml
@@ -30,7 +30,7 @@ on:
 env:
     JHI_RUN_APP: 1
     JHI_JDK: 11
-    JHI_LIB_REPO: https://github.com/jhipster/jhipster.git
+    JHI_LIB_REPO: https://github.com/jhipster/jhipster-bom.git
     JHI_LIB_BRANCH: master
     JHI_GEN_REPO: https://github.com/jhipster/generator-jhipster.git
     JHI_GEN_BRANCH: master


### PR DESCRIPTION
This should at least fix the failing setup for the neo4j builds I suppose.