### PR TITLE
add webflux neo4j test

### DIFF
--- a/.github/workflows/neo4j.yaml
+++ b/.github/workflows/neo4j.yaml
@@ -73,6 +73,7 @@ jobs:
           - react-gradle-neo4j
           - vue-maven-neo4j
           - vue-gradle-neo4j
+          - webflux-neo4j
         include:
           - app-type: ngx-neo4j
             entity: neo4j
@@ -100,6 +101,11 @@ jobs:
             war: 0
             e2e: 1
           - app-type: vue-gradle-neo4j
+            entity: neo4j
+            profile: prod
+            war: 0
+            e2e: 1
+          - app-type: webflux-neo4j
             entity: neo4j
             profile: prod
             war: 0


### PR DESCRIPTION
Looks like we have removed/forgot to add again webflux for neo4j into our daily builds. This explains why we didn't noticed t[his regression earlier](https://github.com/jhipster/generator-jhipster/issues/14196).