### PR TITLE
Change cron for docker-image build to 1st day of month

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -24,7 +24,7 @@ concurrency:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 3 * * *'
+    - cron: '30 3 1 * *'
 jobs:
   builds:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
See https://github.com/hipster-labs/jhipster-daily-builds/actions/workflows/docker-image.yaml

Because it's broken since 2 months:

![image](https://user-images.githubusercontent.com/9156882/201388851-579e4ce5-7eef-4f83-862d-24c107e59c0a.png)
