### PR TITLE
Change cron for windows build to 1st day of month

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -33,7 +33,7 @@ on:
         default: 'main'
         required: false
   schedule:
-    - cron: '30 8 * * *'
+    - cron: '30 8 1 * *'
 env:
   JHI_SAMPLES: ${{ github.workspace }}/jhipster-daily-builds/test-integration/samples
 jobs:


### PR DESCRIPTION
See https://github.com/hipster-labs/jhipster-daily-builds/actions/workflows/windows.yaml

Because it's broken since 2 months:

![image](https://user-images.githubusercontent.com/9156882/201389397-0861e4fa-8139-41fb-a2d7-139e65d6f8c1.png)
