### PR TITLE
Change cron for neo4j build to 1st day of month

### DIFF
--- a/.github/workflows/neo4j.yaml
+++ b/.github/workflows/neo4j.yaml
@@ -33,7 +33,7 @@ on:
         default: 'main'
         required: false
   schedule:
-    - cron: '30 4 * * *'
+    - cron: '30 4 1 * *'
 env:
   JHI_SAMPLES: ${{ github.workspace }}/jhipster-daily-builds/test-integration/samples
 jobs:


### PR DESCRIPTION
See https://github.com/hipster-labs/jhipster-daily-builds/actions/workflows/neo4j.yaml

Because it's broken since 9 months:

![image](https://user-images.githubusercontent.com/9156882/201390003-3e695ca5-8d17-495a-b235-aea4c083df9d.png)
