### PR TITLE
Change cron for no-database builds to 1st day of month

### DIFF
--- a/.github/workflows/no-database.yaml
+++ b/.github/workflows/no-database.yaml
@@ -33,7 +33,7 @@ on:
         default: 'main'
         required: false
   schedule:
-    - cron: '30 2 * * *'
+    - cron: '30 2 1 * *'
 env:
   JHI_SAMPLES: ${{ github.workspace }}/jhipster-daily-builds/test-integration/samples
 jobs:


### PR DESCRIPTION
See https://github.com/hipster-labs/jhipster-daily-builds/actions/workflows/no-database.yaml

Because it's broken since 1 month:

![image](https://user-images.githubusercontent.com/9156882/201390344-cb952926-c09f-4fb1-85fd-2de31dc59118.png)
